### PR TITLE
Add gnome 3.22 support on metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
     "3.14",
     "3.16",
     "3.18",
-    "3.20"      
+    "3.20",
+    "3.22"
   ],
   "url": "https://github.com/BrOrlandi/Desktop-Scroller-GNOME-Extension",
   "uuid": "desktop-scroller@brorlandi",


### PR DESCRIPTION
This extension worked perfectly for me under gnome 3.22 👍 