### PR TITLE
Fix workspacewitcher

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -433,7 +433,7 @@ Scroller.prototype = {
         }
 
         /* Shows the switcher and scrolls */
-        Main.wm._showWorkspaceSwitcher(null, global.screen, null, binding_obj);
+        Main.wm._showWorkspaceSwitcher(global.display, null, binding_obj);
 
         let switcher = Main.wm._workspaceSwitcherPopup;
         if (switcher && add_switcher_handler) {

--- a/metadata.json
+++ b/metadata.json
@@ -6,15 +6,8 @@
     "name": "Desktop Scroller",
     "settings-schema": "org.gnome.shell.extensions.desktop-scroller",
     "shell-version": [
-        "3.13.92",
-        "3.14",
-        "3.16",
-        "3.18",
-        "3.20",
-        "3.22",
-        "3.24",
-        "3.26",
-        "3.28"
+        "3.28",
+        "3.30"
     ],
     "url": "https://github.com/BrOrlandi/Desktop-Scroller-GNOME-Extension",
     "uuid": "desktop-scroller@brorlandi",

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,6 @@
     "name": "Desktop Scroller",
     "settings-schema": "org.gnome.shell.extensions.desktop-scroller",
     "shell-version": [
-        "3.28",
         "3.30"
     ],
     "url": "https://github.com/BrOrlandi/Desktop-Scroller-GNOME-Extension",


### PR DESCRIPTION
Usage of a non-public function has indeed stopped working in Gnome 3.30, and needs to be adapted. The changes are currently not compatible with previous versions of gnome-shell.