### PR TITLE
Update for Gnome 3.38 compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -266,15 +266,12 @@ Scroller.prototype = {
                 break;
         }
 
-        var actor = new Clutter.Rectangle({
-            name: 'scroller_' + edge.name,
-            reactive: true,
-            opacity: 0,
-            x: x,
-            y: y,
-            height: height,
-            width: width
-        });
+        var actor = new Clutter.Actor();
+        actor.set_name('scroller_' + edge.name);
+        actor.set_reactive(true);
+        actor.set_opacity(0);
+        actor.set_position(x, y);
+        actor.set_size(width, height);
 
         return actor;
     },


### PR DESCRIPTION
The Clutter.Rectangle constructor was deprecated, then apparently removed, so the extension failed to load in Gnome 3.38 (Ubuntu 20.10). I replaced it with Clutter.Actor and explicit setters. (It's not clear to me from the API docs if the latter is actually required, but this seems to work.)

https://gjs-docs.gnome.org/clutter4~4_api/clutter.rectangle#constructor-new