### PR TITLE
Fix object.actor deprecation warnings

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -228,7 +228,7 @@ Scroller.prototype = {
 
         /* Make sure we are not over the hot corner */
         if (monitor == Main.layoutManager.primaryMonitor) {
-            y_offset = Main.panel.actor.height;
+            y_offset = Main.panel.height;
             try {
                 x_offset = Main.panel._leftBox.get_children()[0].width;
             } catch (e) {
@@ -437,7 +437,7 @@ Scroller.prototype = {
 
         let switcher = Main.wm._workspaceSwitcherPopup;
         if (switcher && add_switcher_handler) {
-            this._addActor(switcher.actor, true, 'switcher');
+            this._addActor(switcher, true, 'switcher');
         }
     },
 


### PR DESCRIPTION
In Gnome 3.38 (Ubuntu 20.10), I'd see these deprecation warnings on login:
```
Nov 19 12:31:18 sydney gnome-shell[45195]: DesktopScroller: creating bottom actor
Nov 19 12:31:18 sydney gnome-shell[45195]: Usage of object.actor is deprecated for Panel
                                           get@resource:///org/gnome/shell/ui/environment.js:314:29
                                           _createScrollArea@/home/david/.local/share/gnome-shell/extensions/desktop-scroller@brorlandi/extension.js:231:13
                                           _setupEdgeActors@/home/david/.local/share/gnome-shell/extensions/desktop-scroller@brorlandi/extension.js:215:38
                                           _init@/home/david/.local/share/gnome-shell/extensions/desktop-scroller@brorlandi/extension.js:70:14
                                           Scroller@/home/david/.local/share/gnome-shell/extensions/desktop-scroller@brorlandi/extension.js:54:10
                                           enable@/home/david/.local/share/gnome-shell/extensions/desktop-scroller@brorlandi/extension.js:474:23
                                           _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:168:32
                                           _enableAllExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:608:22
                                           _enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:607:37
                                           _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:635:18
                                           _emit@resource:///org/gnome/gjs/modules/core/_signals.js:133:47
                                           _sync@resource:///org/gnome/shell/ui/sessionMode.js:198:14
                                           popMode@resource:///org/gnome/shell/ui/sessionMode.js:166:14
                                           _continueDeactivate@resource:///org/gnome/shell/ui/screenShield.js:502:30
                                           deactivate/<@resource:///org/gnome/shell/ui/screenShield.js:493:44
                                           finish@resource:///org/gnome/shell/gdm/authPrompt.js:528:13
                                           finish@resource:///org/gnome/shell/ui/unlockDialog.js:870:26
                                           deactivate@resource:///org/gnome/shell/ui/screenShield.js:493:26
                                           _onUserBecameActive@resource:///org/gnome/shell/ui/screenShield.js:305:18
Nov 19 12:31:18 sydney gnome-shell[45195]: DesktopScroller: bottom: 0x1727,3072x1
```
and switching workspaces:
```
Nov 19 14:08:10 sydney gnome-shell[45195]: Usage of object.actor is deprecated for WorkspaceSwitcherPopup
                                           get@resource:///org/gnome/shell/ui/environment.js:314:29
                                           _showWorkspaceSwitcher@/home/david/.local/share/gnome-shell/extensions/desktop-scroller@brorlandi/extension.js:448:13
                                           _onScrollEventSwitcher@/home/david/.local/share/gnome-shell/extensions/desktop-scroller@brorlandi/extension.js:401:22
Nov 19 14:08:11 sydney gnome-shell[45195]: DesktopScroller: actor: [0x56259bc9f7b0 Gjs_ui_workspaceSwitcherPopup_WorkspaceSwitcherPopup.workspace-switcher-group:last-child]type (switcher) destroyed
Nov 19 14:08:11 sydney gnome-shell[45195]: DesktopScroller: Disconnecting 551225 from [0x56259bc9f7b0 Gjs_ui_workspaceSwitcherPopup_WorkspaceSwitcherPopup.workspace-switcher-group:last-child]
Nov 19 14:08:11 sydney gnome-shell[45195]: DesktopScroller: Disconnecting 551224 from [0x56259bc9f7b0 Gjs_ui_workspaceSwitcherPopup_WorkspaceSwitcherPopup.workspace-switcher-group:last-child]
```

From irc.gnome.org/#javascript:

> 13:37 < ewlsh[m]> The simple answer is you should stop using the '.actor' part. Anything imports.ui is from GNOME Shell not GJS ( #extensions:gnome.org is the place for that ). You can read the sources for imports.ui here: https://gitlab.gnome.org/GNOME/gnome-shell/-/tree/master/js/ui
> 13:39 < ewlsh[m]> The longer answer is that those objects used to have a .actor property but are now instead subclasses of Actor so you can operate directly on them like panel.height.
> 13:40 < ewlsh[m]> https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/master/js/ui/environment.js#L313
> 13:40 < ewlsh[m]> This code maintains compatibility while logging the error.