### PR TITLE
Gnome 40 and horizontal workspaces

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -385,12 +385,13 @@ Scroller.prototype = {
      * Switches workspaces and shows the switcher overlay.
      */
     _onScrollEventSwitcher: function(actor, event) {
+        let vertical = global.display.get_workspace_manager().layout_rows == -1;
         switch (event.get_scroll_direction()) {
             case Clutter.ScrollDirection.UP:
-                this._showWorkspaceSwitcher('switch-to-workspace-up');
+                this._showWorkspaceSwitcher(vertical ? 'switch-to-workspace-up' : 'switch-to-workspace-left');
                 return true;
             case Clutter.ScrollDirection.DOWN:
-                this._showWorkspaceSwitcher('switch-to-workspace-down');
+                this._showWorkspaceSwitcher(vertical ? 'switch-to-workspace-down' : 'switch-to-workspace-right');
                 return true;
         }
         return false;

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
     "name": "Desktop Scroller",
     "settings-schema": "org.gnome.shell.extensions.desktop-scroller",
     "shell-version": [
-        "3.30"
+        "40"
     ],
     "url": "https://github.com/BrOrlandi/Desktop-Scroller-GNOME-Extension",
     "uuid": "desktop-scroller@brorlandi",

--- a/prefs.js
+++ b/prefs.js
@@ -123,7 +123,6 @@ function init() {
 
 function buildPrefsWidget() {
     let widget = new DesktopScrollerSettingsWidget();
-    widget.show_all();
 
     return widget;
 }


### PR DESCRIPTION
This extension wasn't working with a fresh Ubuntu 21.10 install using Gnome 40. The preferences failed to launch, and the workspaces failed to scroll. I believe I've corrected those issues, but backward compatibility is lost, since the prefs change reflects an [API removal and behavior change](https://gjs.guide/extensions/upgrading/gnome-shell-40.html#show-all-and-destroy) between Gtk 3 and 4.

Additionally, this reflects a default change from vertically arranged to horizontally arranged workspaces (switch left/right instead of up/down). I tried to check for / maintain compatibility with vertical workspaces, but it wasn't immediately clear to me how to reconfigure Gnome 40 to use vertical workspaces, so that's untested. Obviously more work would be needed if someone wanted this to work with vertical AND horizontal workspaces.

You'll need to bump the extension version number yourself before publishing to extensions.gnome.org, if you're so inclined. (I saw feedback on another extension suggesting this should be left to the author/maintainer.)